### PR TITLE
added DeprecationWarning for Workshare recipes

### DIFF
--- a/Workshare/Workshare.download.recipe
+++ b/Workshare/Workshare.download.recipe
@@ -35,7 +35,7 @@ limitations under the License.</string>
 			<key>Arguments</key>
 			<dict>
 				<key>warning_message</key>
-				<string>This recipe has been deprecated, as Workshare is no longer supported for macOS (https://www.litera.com/products/store/workshare-compare/#faq). It will be removed soon.</string>
+				<string>This recipe has been deprecated, as Workshare is no longer supported for macOS (https://www.litera.com/products/store/workshare-compare/#faq). It will be removed after October 25th, 2020.</string>
 			</dict>
 			<key>Processor</key>
 			<string>DeprecationWarning</string>

--- a/Workshare/Workshare.download.recipe
+++ b/Workshare/Workshare.download.recipe
@@ -34,6 +34,15 @@ limitations under the License.</string>
 		<dict>
 			<key>Arguments</key>
 			<dict>
+				<key>warning_message</key>
+				<string>This recipe has been deprecated, as Workshare is no longer supported for macOS (https://www.litera.com/products/store/workshare-compare/#faq). It will be removed soon.</string>
+			</dict>
+			<key>Processor</key>
+			<string>DeprecationWarning</string>
+		</dict>
+		<dict>
+			<key>Arguments</key>
+			<dict>
 				<key>url</key>
 				<string>%DOWNLOAD_URL%</string>
 			</dict>

--- a/Workshare/Workshare.jss.recipe
+++ b/Workshare/Workshare.jss.recipe
@@ -49,7 +49,7 @@ limitations under the License.</string>
 			<key>Arguments</key>
 			<dict>
 				<key>warning_message</key>
-				<string>This recipe has been deprecated, as Workshare is no longer supported for macOS (https://www.litera.com/products/store/workshare-compare/#faq). It will be removed soon.</string>
+				<string>This recipe has been deprecated, as Workshare is no longer supported for macOS (https://www.litera.com/products/store/workshare-compare/#faq). It will be removed after October 25th, 2020.</string>
 			</dict>
 			<key>Processor</key>
 			<string>DeprecationWarning</string>

--- a/Workshare/Workshare.jss.recipe
+++ b/Workshare/Workshare.jss.recipe
@@ -48,6 +48,15 @@ limitations under the License.</string>
 		<dict>
 			<key>Arguments</key>
 			<dict>
+				<key>warning_message</key>
+				<string>This recipe has been deprecated, as Workshare is no longer supported for macOS (https://www.litera.com/products/store/workshare-compare/#faq). It will be removed soon.</string>
+			</dict>
+			<key>Processor</key>
+			<string>DeprecationWarning</string>
+		</dict>
+		<dict>
+			<key>Arguments</key>
+			<dict>
 				<key>category</key>
 				<string>%CATEGORY%</string>
 				<key>groups</key>

--- a/Workshare/Workshare.pkg.recipe
+++ b/Workshare/Workshare.pkg.recipe
@@ -41,7 +41,7 @@ limitations under the License.</string>
 			<key>Arguments</key>
 			<dict>
 				<key>warning_message</key>
-				<string>This recipe has been deprecated, as Workshare is no longer supported for macOS (https://www.litera.com/products/store/workshare-compare/#faq). It will be removed soon.</string>
+				<string>This recipe has been deprecated, as Workshare is no longer supported for macOS (https://www.litera.com/products/store/workshare-compare/#faq). It will be removed after October 25th, 2020.</string>
 			</dict>
 			<key>Processor</key>
 			<string>DeprecationWarning</string>

--- a/Workshare/Workshare.pkg.recipe
+++ b/Workshare/Workshare.pkg.recipe
@@ -40,6 +40,15 @@ limitations under the License.</string>
 		<dict>
 			<key>Arguments</key>
 			<dict>
+				<key>warning_message</key>
+				<string>This recipe has been deprecated, as Workshare is no longer supported for macOS (https://www.litera.com/products/store/workshare-compare/#faq). It will be removed soon.</string>
+			</dict>
+			<key>Processor</key>
+			<string>DeprecationWarning</string>
+		</dict>
+		<dict>
+			<key>Arguments</key>
+			<dict>
 				<key>pkgdirs</key>
 				<dict>
 					<key>Applications</key>


### PR DESCRIPTION
- added DeprecationWarning since [Workshare is no longer supported for macOS](https://www.litera.com/products/store/workshare-compare/#faq)