### PR TITLE
Update and rename Sublime Text.download.recipe to Sublime Text 4.down…

### DIFF
--- a/Sublime Text/Sublime Text 4.download.recipe
+++ b/Sublime Text/Sublime Text 4.download.recipe
@@ -17,7 +17,7 @@ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License.</string>
 	<key>Description</key>
-	<string>Downloads the latest version of Sublime Text from the vendor.</string>
+	<string>Downloads the latest version of Sublime Text 4 from the vendor.</string>
 	<key>Identifier</key>
 	<string>com.github.palantir.download.Sublime Text</string>
 	<key>Input</key>
@@ -25,7 +25,7 @@ limitations under the License.</string>
 		<key>DOWNLOAD_URL</key>
 		<string>https://www.sublimetext.com/download</string>
 		<key>NAME</key>
-		<string>Sublime Text</string>
+		<string>Sublime Text 4</string>
 	</dict>
 	<key>MinimumVersion</key>
 	<string>1.4</string>
@@ -35,9 +35,7 @@ limitations under the License.</string>
 			<key>Arguments</key>
 			<dict>
 				<key>re_pattern</key>
-				<string>/sublime_text_build_(\d+)_mac.zip</string>
-				<key>result_output_var_name</key>
-				<string>BUILD_VERSION</string>
+				<string>(/sublime_text_build_(?P&lt;version&gt;\d+)_mac.zip)</string>
 				<key>url</key>
 				<string>%DOWNLOAD_URL%</string>
 			</dict>
@@ -47,8 +45,10 @@ limitations under the License.</string>
 		<dict>
 			<key>Arguments</key>
 			<dict>
+				<key>filename</key>
+				<string>%NAME%-%version%.zip</string>
 				<key>url</key>
-				<string>https://download.sublimetext.com/sublime_text_build_%BUILD_VERSION%_mac.zip</string>
+				<string>https://download.sublimetext.com%match%</string>
 			</dict>
 			<key>Processor</key>
 			<string>URLDownloader</string>
@@ -60,10 +60,6 @@ limitations under the License.</string>
 		<dict>
 			<key>Arguments</key>
 			<dict>
-				<key>archive_path</key>
-				<string>%pathname%</string>
-				<key>destination_path</key>
-				<string>%RECIPE_CACHE_DIR%/%NAME%</string>
 				<key>purge_destination</key>
 				<true/>
 			</dict>
@@ -73,22 +69,31 @@ limitations under the License.</string>
 		<dict>
 			<key>Arguments</key>
 			<dict>
-				<key>input_plist_path</key>
-				<string>%RECIPE_CACHE_DIR%/%NAME%/%NAME%.app/Contents/Info.plist</string>
+				<key>input_path</key>
+				<string>%RECIPE_CACHE_DIR%/%NAME%/Sublime Text.app</string>
+				<key>requirement</key>
+				<string>identifier "com.sublimetext.4" and anchor apple generic and certificate 1[field.1.2.840.113635.100.6.2.6] /* exists */ and certificate leaf[field.1.2.840.113635.100.6.1.13] /* exists */ and certificate leaf[subject.OU] = Z6D26JE4Y4</string>
+				<key>strict_verification</key>
+				<true/>
 			</dict>
 			<key>Processor</key>
-			<string>Versioner</string>
+			<string>CodeSignatureVerifier</string>
 		</dict>
 		<dict>
 			<key>Arguments</key>
 			<dict>
-				<key>input_path</key>
-				<string>%RECIPE_CACHE_DIR%/%NAME%/%NAME%.app</string>
-				<key>requirement</key>
-				<string>identifier "com.sublimetext.4" and anchor apple generic and certificate 1[field.1.2.840.113635.100.6.2.6] /* exists */ and certificate leaf[field.1.2.840.113635.100.6.1.13] /* exists */ and certificate leaf[subject.OU] = Z6D26JE4Y4</string>
+				<key>info_path</key>
+				<string>%RECIPE_CACHE_DIR%/%NAME%/Sublime Text.app/Contents/Info.plist</string>
+				<key>plist_keys</key>
+				<dict>
+					<key>CFBundleVersion</key>
+					<string>version</string>
+					<key>LSMinimumSystemVersion</key>
+					<string>min_os_version</string>
+				</dict>
 			</dict>
 			<key>Processor</key>
-			<string>CodeSignatureVerifier</string>
+			<string>PlistReader</string>
 		</dict>
 	</array>
 </dict>


### PR DESCRIPTION
…load.recipe

- Replace %NAME%.app references with actual app name since it's not a safe assumption that admins will leave the `NAME` input variable 'Sublime Text'
- Collect full download URL as `%match%` so we only have the 1 `re_pattern` to update in the event the naming convention changes in future, but still collect version
- Specify filename format for `URLDownloader`
- Replace `Versioner` processor with `PlistReader` so we can collect the min supported OS version as well
- Move `CodeSignatureVerifier` before collection of version for verification and add `strict_verification`
- Specify major version 4 in `NAME` input variable since code signature includes this
- Remove unnecessary Unarchiver arguments since the specified values are what's used by default.