### PR TITLE
created recipes for YubiKey Manager CLI

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,6 +1,6 @@
 repos:
 -   repo: https://github.com/homebysix/pre-commit-macadmin
-    rev: v1.15.0
+    rev: v1.19.0
     hooks:
     -   id: check-autopkg-recipes
         args: ["--recipe-prefix=com.github.palantir."]

--- a/Microsoft/DotNet Core Uninstall Tool.download.recipe
+++ b/Microsoft/DotNet Core Uninstall Tool.download.recipe
@@ -19,6 +19,8 @@ limitations under the License.</string>
 	<key>Description</key>
 	<string>Downloads the latest version of dotnet-core-uninstall from the vendor.
 
+Set %include_prereleases% to true in your override to package prerelease builds in your environment.
+
 The recipe name can be replaced in overrides, but we recommend not using ".NET" as a prepend, as this can cause PkgCreator and other processors to fail with errors.</string>
 	<key>Identifier</key>
 	<string>com.github.palantir.download.DotNet Core Uninstall Tool</string>
@@ -28,6 +30,8 @@ The recipe name can be replaced in overrides, but we recommend not using ".NET" 
 		<string>dotnet-core-uninstall</string>
 		<key>REPO</key>
 		<string>dotnet/cli-lab</string>
+		<key>include_prereleases</key>
+		<false/>
 	</dict>
 	<key>MinimumVersion</key>
 	<string>0.5.0</string>

--- a/Palantir/GPG Tap Notifier.download.recipe
+++ b/Palantir/GPG Tap Notifier.download.recipe
@@ -19,7 +19,7 @@ limitations under the License.</string>
 	<key>Description</key>
 	<string>Downloads the latest version of GPG Tap Notifier from the vendor.
 
-Set %include_prereleases% to true in your override to package prelease builds in your environment.</string>
+Set %include_prereleases% to true in your override to package prerelease builds in your environment.</string>
 	<key>Identifier</key>
 	<string>com.github.palantir.download.GPG Tap Notifier</string>
 	<key>Input</key>

--- a/Palantir/log4j-sniffer.download.recipe
+++ b/Palantir/log4j-sniffer.download.recipe
@@ -19,7 +19,7 @@ limitations under the License.</string>
 	<key>Description</key>
 	<string>Downloads the latest version of log4j-sniffer from the vendor.
 
-Set %include_prereleases% to true in your override to package prelease builds in your environment.
+Set %include_prereleases% to true in your override to package prerelease builds in your environment.
 
 Valid PLATFORM_ARCH arguments:
 - "arm64": log4j-sniffer for Apple Silicon Macs (default)

--- a/README.md
+++ b/README.md
@@ -1,23 +1,33 @@
 # autopkg-recipes
 
 ## About
+
 This is a collection of AutoPkg recipes used to automate the process of packaging and deploying Mac applications.
 
 ## Usage
+
 See [AutoPkg's documentation](https://github.com/autopkg/autopkg/wiki/Getting-Started) for instructions on using these recipes in your AutoPkg installation.
 
 ## Contributing
+
 We welcome all contributions from the open source community to be submitted for review (in the form of GitHub pull requests). Feel free to fork this project and submit changes for approval. Thank you so much for taking the time to contribute!
 
 ## Reference Links
 
 ### AutoPkg
+
 [AutoPkg](https://autopkg.github.io/autopkg/) is a system for automatically preparing software for distribution to managed clients.
 
 ### JamfUploader
-A collection of Autopkg processors used for all the .jamf-upload recipes in this repository. Note that [using JamfUploader](https://github.com/grahampugh/jamf-upload/wiki/JamfUploader-AutoPkg-Processors#using-the-processors) requires adding the `grahampugh-recipes` repo to your AutoPkg preferences. The .jamf-upload recipes in this repo will upload the package to Jamf Pro (as well as its package category), but an override must be created for any additional JamfUploader actions, including creating or updating an associated policy.
+
+The .jamf-upload recipes in this repo run the JamfPackageUploader processor written by Graham Pugh to upload a .pkg payload to Jamf (as well as its package category), but an override must be created for any additional JamfUploader actions, including creating or updating an associated policy.. Running recipe overrides of these recipes will require adding JamfUploader's repository to AutoPkg by running `autopkg repo-add grahampugh-recipes`. See the [JamfUploader wiki](https://github.com/grahampugh/jamf-upload/wiki/JamfUploader-AutoPkg-Processors#using-the-processors) for more information on using this family of processors in your recipes.
+
+### AppIconExtractor
+
+Several .pkg recipes in this repo run the AppIconExtractor processor written by Matthew Warren to prepare an icon file for use in recipe overrides, such as JamfUploader workflows. Running recipe overrides of these recipes will require adding AppIconExtractor's repository to AutoPkg by running `autopkg repo-add haircut-recipes`. [See Automatically Export and Generate App Icons in AutoPkg Recipes](https://macblog.org/autopkg-icons/) for more information on using this processor in your recipes.
 
 ### MacAdmins Slack
+
 [MacAdmins Slack](https://www.macadmins.org) is a great way to reach out for questions about Mac management and participate in the Mac admin community.
 
 ## License

--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ See [AutoPkg's documentation](https://github.com/autopkg/autopkg/wiki/Getting-St
 
 We welcome all contributions from the open source community to be submitted for review (in the form of GitHub pull requests). Feel free to fork this project and submit changes for approval. Thank you so much for taking the time to contribute!
 
-## Shared AutoPkg Processors
+## Third-Party AutoPkg Processors
 
 The recipes in this repository make use of some third-party shared processors to accomplish workflows not included in the core AutoPkg product. The sections below include the source repository and documentation for each processor. To add these shared processors' repositories to AutoPkg, run `autopkg repo-add $repo` for each repo.
 

--- a/README.md
+++ b/README.md
@@ -24,7 +24,7 @@ The .jamf-upload recipes in this repo run the JamfPackageUploader processor writ
 
 ### AppIconExtractor
 
-Several .pkg recipes in this repo run the AppIconExtractor processor written by Matthew Warren to prepare an icon file for use in recipe overrides, such as JamfUploader workflows. Running recipe overrides of these recipes will require adding AppIconExtractor's repository to AutoPkg by running `autopkg repo-add haircut-recipes`. [See Automatically Export and Generate App Icons in AutoPkg Recipes](https://macblog.org/autopkg-icons/) for more information on using this processor in your recipes.
+Several .pkg recipes in this repo run the AppIconExtractor processor written by Matthew Warren to prepare an icon file for use in recipe overrides, such as JamfUploader workflows. Running recipe overrides of these recipes will require adding AppIconExtractor's repository to AutoPkg by running `autopkg repo-add haircut-recipes`. See [Automatically Export and Generate App Icons in AutoPkg Recipes](https://macblog.org/autopkg-icons/) for more information on using this processor in your recipes.
 
 ### MacAdmins Slack
 

--- a/README.md
+++ b/README.md
@@ -12,23 +12,61 @@ See [AutoPkg's documentation](https://github.com/autopkg/autopkg/wiki/Getting-St
 
 We welcome all contributions from the open source community to be submitted for review (in the form of GitHub pull requests). Feel free to fork this project and submit changes for approval. Thank you so much for taking the time to contribute!
 
+## Shared AutoPkg Processors
+
+The recipes in this repository make use of some third-party shared processors to accomplish workflows not included in the core AutoPkg product. The sections below include the source repository and documentation for each processor. To add these shared processors' repositories to AutoPkg, run `autopkg repo-add $repo` for each repo.
+
+### AppIconExtractor
+
+- Source: `haircut-recipes`
+- Documentation: [Automatically Export and Generate App Icons in AutoPkg Recipes](https://macblog.org/autopkg-icons/)
+
+Several .pkg recipes in this repo run the AppIconExtractor processor to prepare an icon file for use in recipe overrides, such as JamfUploader workflows.
+
+### ExeVersionExtractor
+
+- Source: `hansen-m-recipes`
+
+1Password-Win.download.recipe runs this processor to determine the downloaded application version.
+
+### JamfUploader
+
+- Source: `grahampugh-recipes`
+- Documentation: [JamfUploader wiki](https://github.com/grahampugh/jamf-upload/wiki/JamfUploader-AutoPkg-Processors)
+
+The .jamf-upload recipes in this repo run the JamfPackageUploader and JamfCategoryUploader processors to upload a .pkg payload to Jamf along with its package category, but an override must be created for any additional JamfUploader actions, including creating or updating an associated policy.
+
+### MSIVersionProvider
+
+- Source: `hansen-m-recipes`
+- Documentation: [Processors for Windows Software](https://github.com/autopkg/hansen-m-recipes/tree/master/SharedProcessors#msiinfoversionproviderpy)
+
+Box-Win.download.recipe runs this processor to determine the downloaded application version.
+
+### StringReplacer
+
+- Source: `grahampugh-recipes`
+- Documentation: [Common Processors](https://github.com/autopkg/grahampugh-recipes/tree/main/CommonProcessors#StringReplacer)
+
+uTrust Common Driver.pkg.recipe runs this processor to convert the version string to a standard format.
+
+### VariableFromPath
+
+- Source: `magnusviri-recipes`
+- Documentation: [AutoPkg notes](https://magnusviri.com/autopkg-notes.html)
+
+uTrust Common Driver.pkg.recipe runs this processor to extract the version string from the downloaded file's name.
+
 ## Reference Links
 
 ### AutoPkg
 
 [AutoPkg](https://autopkg.github.io/autopkg/) is a system for automatically preparing software for distribution to managed clients.
 
-### JamfUploader
-
-The .jamf-upload recipes in this repo run the JamfPackageUploader processor written by Graham Pugh to upload a .pkg payload to Jamf (as well as its package category), but an override must be created for any additional JamfUploader actions, including creating or updating an associated policy.. Running recipe overrides of these recipes will require adding JamfUploader's repository to AutoPkg by running `autopkg repo-add grahampugh-recipes`. See the [JamfUploader wiki](https://github.com/grahampugh/jamf-upload/wiki/JamfUploader-AutoPkg-Processors#using-the-processors) for more information on using this family of processors in your recipes.
-
-### AppIconExtractor
-
-Several .pkg recipes in this repo run the AppIconExtractor processor written by Matthew Warren to prepare an icon file for use in recipe overrides, such as JamfUploader workflows. Running recipe overrides of these recipes will require adding AppIconExtractor's repository to AutoPkg by running `autopkg repo-add haircut-recipes`. See [Automatically Export and Generate App Icons in AutoPkg Recipes](https://macblog.org/autopkg-icons/) for more information on using this processor in your recipes.
-
 ### MacAdmins Slack
 
 [MacAdmins Slack](https://www.macadmins.org) is a great way to reach out for questions about Mac management and participate in the Mac admin community.
 
 ## License
+
 This project is made available under the [Apache 2.0 License](http://www.apache.org/licenses/LICENSE-2.0).

--- a/Yubico/YubiKey Manager CLI.download.recipe
+++ b/Yubico/YubiKey Manager CLI.download.recipe
@@ -1,0 +1,83 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>Comment</key>
+	<string>Copyright 2025 Palantir Technologies, Inc.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.</string>
+	<key>Description</key>
+	<string>Downloads the latest version of YubiKey Manager CLI (ykman) from the vendor.
+
+Set %include_prereleases% to true in your override to package prerelease builds in your environment.</string>
+	<key>Identifier</key>
+	<string>com.github.palantir.download.YubiKey Manager CLI</string>
+	<key>Input</key>
+	<dict>
+		<key>NAME</key>
+		<string>YubiKey Manager CLI</string>
+		<key>REPO</key>
+		<string>Yubico/yubikey-manager</string>
+		<key>include_prereleases</key>
+		<false/>
+	</dict>
+	<key>MinimumVersion</key>
+	<string>0.5.0</string>
+	<key>Process</key>
+	<array>
+		<dict>
+			<key>Arguments</key>
+			<dict>
+				<key>asset_regex</key>
+				<string>yubikey-manager-*-mac.pkg$</string>
+				<key>github_repo</key>
+				<string>%REPO%</string>
+			</dict>
+			<key>Comment</key>
+			<string>GitHubReleasesInfoProvider processor run for .pkg download.</string>
+			<key>Processor</key>
+			<string>GitHubReleasesInfoProvider</string>
+		</dict>
+		<dict>
+			<key>Arguments</key>
+			<dict>
+				<key>filename</key>
+				<string>%NAME%-%version%.pkg</string>
+			</dict>
+			<key>Comment</key>
+			<string>URLDownloader processor run.</string>
+			<key>Processor</key>
+			<string>URLDownloader</string>
+		</dict>
+		<dict>
+			<key>Arguments</key>
+			<dict>
+				<key>expected_authority_names</key>
+				<array>
+					<string>Developer ID Installer: Yubico Limited (LQA3CS5MM7)</string>
+					<string>Developer ID Certification Authority</string>
+					<string> Apple Root CA</string>
+				</array>
+				<key>input_path</key>
+				<string>%pathname%</string>
+			</dict>
+			<key>Processor</key>
+			<string>CodeSignatureVerifier</string>
+		</dict>
+		<dict>
+			<key>Processor</key>
+			<string>EndOfCheckPhase</string>
+		</dict>
+	</array>
+</dict>
+</plist>

--- a/Yubico/YubiKey Manager CLI.jamf-upload.recipe
+++ b/Yubico/YubiKey Manager CLI.jamf-upload.recipe
@@ -1,0 +1,67 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>Comment</key>
+	<string>Copyright 2025 Palantir Technologies, Inc.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.</string>
+	<key>Description</key>
+	<string>Downloads the latest version of YubiKey Manager CLI (ykman) from the vendor, then uploads it to Jamf Pro.</string>
+	<key>Identifier</key>
+	<string>com.github.palantir.jamf-upload.YubiKey Manager CLI</string>
+	<key>Input</key>
+	<dict>
+		<key>PACKAGE_CATEGORY</key>
+		<string>Utility</string>
+		<key>UPDATE_PREDICATE</key>
+		<string>pkg_uploaded == False</string>
+	</dict>
+	<key>MinimumVersion</key>
+	<string>2.0.2</string>
+	<key>ParentRecipe</key>
+	<string>com.github.palantir.pkg.YubiKey Manager CLI</string>
+	<key>Process</key>
+	<array>
+		<dict>
+			<key>Arguments</key>
+			<dict>
+				<key>category_name</key>
+				<string>%PACKAGE_CATEGORY%</string>
+			</dict>
+			<key>Comment</key>
+			<string>JamfCategoryUploader processor run for category used for package.</string>
+			<key>Processor</key>
+			<string>com.github.grahampugh.jamf-upload.processors/JamfCategoryUploader</string>
+		</dict>
+		<dict>
+			<key>Arguments</key>
+			<dict>
+				<key>pkg_category</key>
+				<string>%PACKAGE_CATEGORY%</string>
+			</dict>
+			<key>Processor</key>
+			<string>com.github.grahampugh.jamf-upload.processors/JamfPackageUploader</string>
+		</dict>
+		<dict>
+			<key>Arguments</key>
+			<dict>
+				<key>predicate</key>
+				<string>%UPDATE_PREDICATE%</string>
+			</dict>
+			<key>Processor</key>
+			<string>StopProcessingIf</string>
+		</dict>
+	</array>
+</dict>
+</plist>

--- a/Yubico/YubiKey Manager CLI.pkg.recipe
+++ b/Yubico/YubiKey Manager CLI.pkg.recipe
@@ -26,6 +26,8 @@ Set %include_prereleases% to true in your override to package prerelease builds 
 	<dict/>
 	<key>MinimumVersion</key>
 	<string>0.5.0</string>
+	<key>ParentRecipe</key>
+	<string>com.github.palantir.download.YubiKey Manager CLI</string>
 	<key>Process</key>
 	<array>
 		<dict>

--- a/Yubico/YubiKey Manager CLI.pkg.recipe
+++ b/Yubico/YubiKey Manager CLI.pkg.recipe
@@ -17,20 +17,13 @@ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License.</string>
 	<key>Description</key>
-	<string>Downloads the latest version of YubiKey Manager CLI (ykman) from the vendor.
+	<string>Downloads the latest version of YubiKey Manager CLI (ykman) from the vendor, then runs code signature verfication on the pkg installer.
 
 Set %include_prereleases% to true in your override to package prerelease builds in your environment.</string>
 	<key>Identifier</key>
-	<string>com.github.palantir.download.YubiKey Manager CLI</string>
+	<string>com.github.palantir.pkg.YubiKey Manager CLI</string>
 	<key>Input</key>
-	<dict>
-		<key>NAME</key>
-		<string>YubiKey Manager CLI</string>
-		<key>REPO</key>
-		<string>Yubico/yubikey-manager</string>
-		<key>include_prereleases</key>
-		<false/>
-	</dict>
+	<dict/>
 	<key>MinimumVersion</key>
 	<string>0.5.0</string>
 	<key>Process</key>
@@ -38,30 +31,17 @@ Set %include_prereleases% to true in your override to package prerelease builds 
 		<dict>
 			<key>Arguments</key>
 			<dict>
-				<key>asset_regex</key>
-				<string>yubikey-manager-*-mac.pkg$</string>
-				<key>github_repo</key>
-				<string>%REPO%</string>
+				<key>expected_authority_names</key>
+				<array>
+					<string>Developer ID Installer: Yubico Limited (LQA3CS5MM7)</string>
+					<string>Developer ID Certification Authority</string>
+					<string> Apple Root CA</string>
+				</array>
+				<key>input_path</key>
+				<string>%pathname%</string>
 			</dict>
-			<key>Comment</key>
-			<string>GitHubReleasesInfoProvider processor run for .pkg download.</string>
 			<key>Processor</key>
-			<string>GitHubReleasesInfoProvider</string>
-		</dict>
-		<dict>
-			<key>Arguments</key>
-			<dict>
-				<key>filename</key>
-				<string>%NAME%-%version%.pkg</string>
-			</dict>
-			<key>Comment</key>
-			<string>URLDownloader processor run.</string>
-			<key>Processor</key>
-			<string>URLDownloader</string>
-		</dict>
-		<dict>
-			<key>Processor</key>
-			<string>EndOfCheckPhase</string>
+			<string>CodeSignatureVerifier</string>
 		</dict>
 	</array>
 </dict>


### PR DESCRIPTION
- created recipes for YubiKey Manager CLI: download, pkg, and jamf-upload
- added include_prereleases input to all download recipes that run GitHubReleasesInfoProvider (defaults to false, allows overrides to switch to true)
- updated pre-commit-macadmin rev to v1.19.0 in .pre-commit-config.yaml
- listed all third-party AutoPkg processors in README with source repo names and links to documentation